### PR TITLE
SlackUpdate

### DIFF
--- a/functions/Convert-DbcResult.ps1
+++ b/functions/Convert-DbcResult.ps1
@@ -74,13 +74,6 @@ function Convert-DbcResult {
         $table.columns.add($col9)
         $table.columns.add($col10)
 
-        Write-PSFMessage "Testing we have a Test Results object" -Level Verbose
-        if (-not $TestResults -or $TestResult) {
-            Write-PSFMessage "It may be that we don't have a Test Results Object" -Level Significant
-            Write-PSFMessage "It might be that you have custom checks in which case we will move on. Otherwise......." -Level Significant
-            Write-PSFMessage "It is possible You forget the -PassThru parameter on Invoke-DbcCheck?" -Level Warning
-            Return ''
-        }
     }
     process {
         Write-PSFMessage "Processing the test results" -Level Verbose
@@ -120,5 +113,13 @@ function Convert-DbcResult {
     }
     end {
         Write-Output -NoEnumerate -InputObject $table
+
+        Write-PSFMessage "Testing we have a Test Results object" -Level Verbose
+        if (-not $TestResults -or $TestResult) {
+            Write-PSFMessage "It may be that we don't have a Test Results Object" -Level Significant
+            Write-PSFMessage "It might be that you have custom checks in which case we will move on. Otherwise......." -Level Significant
+            Write-PSFMessage "It is possible You forget the -PassThru parameter on Invoke-DbcCheck?" -Level Warning
+            Return ''
+        }
     }
 }


### PR DESCRIPTION
peturgretars on slack noted the info messages about the test object where at the start of the invoke, moved to the end block to stop them showing unless you forget -PassThru

# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[] There are 0 failing Pester tests

## Changes this PR brings

Please add below the changes that this PR covers. It doesnt need an essay just the bullet points :-)

Convert-DbcResult was showing messages re -PassThru even if it had been switched on, moved code to end block to only capture if -PassThru wasn't passed