### PR TITLE
New Check - Database snapshots older than retention period

### DIFF
--- a/internal/assertions/Database.Assertions.ps1
+++ b/internal/assertions/Database.Assertions.ps1
@@ -126,6 +126,15 @@ function Assert-ContainedDBSQLAuth {
     )
     @(Get-DbaDbUser -SQLInstance $Instance -Database $Database | Where-Object {$_.LoginType -eq "SqlLogin" -and $_.HasDbAccess -eq $true}).Count | Should -Be 0 -Because "We expect there to be no sql authenticated users in contained database $Database on $Instance"
 }
+
+function Assert-DatabaseSnaphot {
+    Param (
+        [string]$Instance,
+        [string]$Database,
+        [int]$SnapshotRetentionDays
+    )
+    @(Get-DbaDbSnapshot -SQLInstance $Instance -Database $Database | Where-Object {$_.CreateDate -lt (Get-Date).AddDays(-$SnapshotRetentionDays)}).Count | Should -Be 0 -Because "We expect there to be no database snapshots older than the retention period on database $Database on $Instance"
+}
 # SIG # Begin signature block
 # MIINEAYJKoZIhvcNAQcCoIINATCCDP0CAQExCzAJBgUrDgMCGgUAMGkGCisGAQQB
 # gjcCAQSgWzBZMDQGCisGAQQBgjcCAR4wJgIDAQAABBAfzDtgWUsITrck0sYpfvNR

--- a/internal/configurations/DbcCheckDescriptions.json
+++ b/internal/configurations/DbcCheckDescriptions.json
@@ -523,6 +523,10 @@
         "Description": "Tests to see Query Store is disabled on each database except those specified."
     },
     {
+        "UniqueTag": "Snapshot",
+        "Description": "Tests to see if there are database snapshots older than the retention period."
+    },
+    {
         "UniqueTag": "ContainedDBSQLAuth",
         "Description": "Tests to see a contained database contains sql authenticated users."
     },

--- a/internal/configurations/configuration.ps1
+++ b/internal/configurations/configuration.ps1
@@ -163,8 +163,9 @@ Set-PSFConfig -Module dbachecks -Name database.querystoredisabled.excludedb -Val
 Set-PSFConfig -Module dbachecks -Name policy.database.filegrowthdaystocheck -Value $null -Initialize -Description "The number of days to go back to check for growth events"
 Set-PSFConfig -Module dbachecks -Name policy.database.trustworthyexcludedb -Value @() -Initialize -Description "A List of databases that we do not want to check for Trustworthy being on"
 Set-PSFConfig -Module dbachecks -Name policy.database.duplicateindexexcludedb -Value @('msdb','ReportServer','ReportServerTempDB') -Initialize -Description "A List of databases we do not want to check for Duplicate Indexes"
-Set-PSFConfig -Module dbachecks -Name policy.database.clrassembliessafeexcludedb -Value @() -Initialize -Description " A List of database what we do not want to check for SAFE CLR Assemblies"
-Set-PSFConfig -Module dbachecks -Name policy.database.logfilepercentused -Value 75 -Initialize -Description " The % log used we should stay below"
+Set-PSFConfig -Module dbachecks -Name policy.database.clrassembliessafeexcludedb -Value @() -Initialize -Description "A List of database what we do not want to check for SAFE CLR Assemblies"
+Set-PSFConfig -Module dbachecks -Name policy.database.logfilepercentused -Value 75 -Initialize -Description "The % log used we should stay below"
+Set-PSFConfig -Module dbachecks -Name policy.database.snapshotretention -Value 0 -Initialize -Description "There should be no database snapshots older than this number of days"
 
 # Policy for Ola Hallengren Maintenance Solution
 Set-PSFConfig -Module dbachecks -name policy.ola.installed -Validation bool -Value $true -Initialize -Description "Checks to see if Ola Hallengren solution is installed"
@@ -289,6 +290,7 @@ Set-PSFConfig -Module dbachecks -Name skip.security.nonstandardport -Validation 
 Set-PSFConfig -Module dbachecks -Name skip.security.SQLMailXPsDisabled -Validation bool -Value $true -Initialize -Description "Skip the check for Sql Mail XPs being disabled"
 Set-PSFConfig -Module dbachecks -Name skip.security.PublicPermission -Validation bool -Value $true -Initialize -Description "Skips the check for whether public role has permissions"
 Set-PSFConfig -Module dbachecks -Name skip.security.serverprotocol -Validation bool -Value $true -Initialize -Description "Skips the check for whether SQL Server is running on any other protocols but TCP/IP"
+Set-PSFConfig -Module dbachecks -Name skip.database.snapshot -Validation bool -Value $false -Initialize -Description "Skips the check for whether there are database snapshots past the retention period"
 #agent
 Set-PSFConfig -Module dbachecks -Name agent.dbaoperatorname -Value $null -Initialize -Description "Name of the DBA Operator in SQL Agent"
 Set-PSFConfig -Module dbachecks -Name agent.dbaoperatoremail -Value $null -Initialize -Description "Email address of the DBA Operator in SQL Agent"


### PR DESCRIPTION
## Please confirm you have 0 failing Pester Tests

- [X] There are 0 failing Pester tests
```
Tests completed in 18.17s
Tests Passed: 2187, Failed: 0, Skipped: 0, Pending: 0, Inconclusive: 0
```

## Changes this PR brings

- New check for database snapshots older than retention period
- config property to control the retention period - default is 0 days
- config property to skip the test (not 100% sure if it needed this)