### PR TITLE
Add latestbuild check

### DIFF
--- a/source/checks/Instancev5.Tests.ps1
+++ b/source/checks/Instancev5.Tests.ps1
@@ -346,6 +346,15 @@ Describe "Error Log Entries" -Tag ErrorLog, Medium, Instance -ForEach $Instances
     }
 }
 
+Describe "Latest Build" -Tag LatestBuild, Security, CIS, Medium, Instance -ForEach $InstancesToTest {
+    $skip = ($__dbcconfig | Where-Object { $_.Name -eq 'skip.instance.latestbuild' }).Value
+    Context "Testing Latest Build on <_.Name>" {
+        It "The Latest Build of SQL should be installed on <_.Name>" -Skip:$skip {
+            $psitem.LatestBuild.Compliant | Should -BeTrue -Because "being patched to the latest version is important"
+        }
+    }
+}
+
 <#
 Describe "TempDB Configuration" -Tags TempDbConfiguration, Medium, Instance -ForEach $InstancesToTest {
     Context "Testing TempDB Configuration on $psitem" -Skip:(($__dbcconfig | Where-Object { $_.Name

--- a/source/internal/functions/NewGet-AllInstanceInfo.ps1
+++ b/source/internal/functions/NewGet-AllInstanceInfo.ps1
@@ -270,6 +270,9 @@ function NewGet-AllInstanceInfo {
             # It is not enough to check the CreateDate on the log, you must check the LogDate on every error record as well.
             $ErrorLogCount = (Get-ErrorLogEntry | Where-Object { $psitem.LogDate -gt (Get-Date).AddDays( - $LogWindow) }).Count
         }
+        'LatestBuild' {
+            $LatestBuild = Test-DbaBuild -SqlInstance $Instance -Latest
+        }
         'TempDbConfiguration' {
             $TempDBTest = Test-DbaTempDbConfig -SqlInstance $Instance
         }
@@ -373,6 +376,9 @@ function NewGet-AllInstanceInfo {
             logWindow     = $logWindow
         }
         InstanceConnection    = $InstanceConnection
+        LatestBuild           = [PSCustomObject]@{
+            Compliant = $LatestBuild.Compliant
+        }
         # TempDbConfig          = [PSCustomObject]@{
         #     TF118EnabledCurrent     = $tempDBTest[0].CurrentSetting
         #     TF118EnabledRecommended = $tempDBTest[0].Recommended


### PR DESCRIPTION
# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[😄 ] There are 0 failing Pester tests

## Changes this PR brings

```
Running with

latestbuild

Checks against 3 SQL Containers

With original Code it takes 4.09 Seconds
With New Code it takes 4.42 Seconds

New Code for these 1 checks
is saving -0.34 seconds
from a run of 4.09 seconds
New Code runs in 108.23 % of the time

[20:05:03][Invoke-PerfAndValidateCheck]
The Tags are the same
[20:05:03][Invoke-PerfAndValidateCheck]
The Total Tests Run are the same 3 3

[20:05:03][Invoke-PerfAndValidateCheck]
The Total Tests Passed are the same 3 3

[20:05:03][Invoke-PerfAndValidateCheck]
The Total Tests Failed are the same 0 0

[20:05:03][Invoke-PerfAndValidateCheck]
The Total Tests Skipped are the same 0 0
```