### PR TITLE
Fixed branch rename in documentation links

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -275,7 +275,7 @@ stages:
 
   - stage: Deploy
     dependsOn: Test
-    # Only execute deploy stage if we're on master and previous stage succeeded
+    # Only execute deploy stage if we're on main and previous stage succeeded
     condition: |
       and(
         succeeded(),

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   require_ci_to_pass: no
-  # master should be the baseline for reporting
+  # main should be the baseline for reporting
   branch: main
 
 comment:

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,11 +24,11 @@ Have questions about development? Please visit our [Wiki](https://github.com/sql
     </tr>
     <tr>
       <td><a href-"https://sqlcollaborative.visualstudio.com/dbachecks/_build/index?context=mine&path=%5C&definitionId=2&_a=completed"><img align="left" src="https://sqlcollaborative.visualstudio.com/_apis/public/build/definitions/a0deae7b-ae38-4ecc-a836-5f79cc561140/2/badge"></a></td>
-      <td>Master Branch Build - Module version update and Code Signing <a href="https://sqlcollaborative.visualstudio.com/dbachecks/_build/index?context=mine&path=%5C&definitionId=2&_a=completed" target="_blank">Click Here</a></td>
+      <td>Main Branch Build - Module version update and Code Signing <a href="https://sqlcollaborative.visualstudio.com/dbachecks/_build/index?context=mine&path=%5C&definitionId=2&_a=completed" target="_blank">Click Here</a></td>
     </tr>
         <tr>
       <td><a href = "https://sqlcollaborative.visualstudio.com/dbachecks/_releases2?definitionId=3&view=mine&_a=releases"><img align="left" src="https://sqlcollaborative.vsrm.visualstudio.com/_apis/public/Release/badge/a0deae7b-ae38-4ecc-a836-5f79cc561140/2/2"></a></td>
-          <td>Master Branch Release - Release to PowerShell Gallery <a href="https://sqlcollaborative.visualstudio.com/dbachecks/_releases2?definitionId=3&view=mine&_a=releases" target="_blank">Click Here</a></td>
+          <td>Main Branch Release - Release to PowerShell Gallery <a href="https://sqlcollaborative.visualstudio.com/dbachecks/_releases2?definitionId=3&view=mine&_a=releases" target="_blank">Click Here</a></td>
     </tr>
   </tbody>
 </table>

--- a/header-mkdocs.yml
+++ b/header-mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: dbachecks
 repo_url: https://github.com/sqlcollaborative/dbachecks
 site_author: The Beard
-edit_uri: edit/master/docs/
+edit_uri: edit/main/docs/
 theme: readthedocs
-copyright: "dbachecks is licensed under the <a href='https://github.com/sqlcollaborative/dbachecks/raw/master/LICENSE'>MIT license"
+copyright: "dbachecks is licensed under the <a href='https://github.com/sqlcollaborative/dbachecks/raw/main/LICENSE'>MIT license"
 pages:
   - Home: index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: dbachecks
 repo_url: https://github.com/sqlcollaborative/dbachecks
 site_author: The Beard
-edit_uri: edit/master/docs/
+edit_uri: edit/main/docs/
 theme: readthedocs
 copyright: "dbachecks is licensed under the <a href='https://github.com/sqlcollaborative/dbachecks/raw/master/LICENSE'>MIT license"
 pages:

--- a/readme.md
+++ b/readme.md
@@ -35,17 +35,17 @@ This open source module allows us to crowd-source our checklists using [Pester](
 
 You can find a set of interactive PowerShell Notebooks which will introduce you to all of the core concepts in Robs GitHub. There is a set of .NET interactive Jupyter Notebooks
 
-https://github.com/SQLDBAWithABeard/JupyterNotebooks/tree/master/notebooks/dotNETNotebooks/dbachecks
+https://github.com/SQLDBAWithABeard/JupyterNotebooks/tree/main/notebooks/dotNETNotebooks/dbachecks
 
 and a set of Jupyter Notebooks that will run in Azure Data Studio
 
-https://github.com/SQLDBAWithABeard/JupyterNotebooks/tree/master/notebooks/NotDotNet/dbachecks
+https://github.com/SQLDBAWithABeard/JupyterNotebooks/tree/main/notebooks/NotDotNet/dbachecks
 
 Both will use a docker container to show you how dbachecks works.
 
 There is a zip file containing the Notebooks here
 
-https://github.com/SQLDBAWithABeard/Presentations/raw/master/Notebooks/dbachecks/Notebooks.zip
+https://github.com/SQLDBAWithABeard/Presentations/raw/main/Notebooks/dbachecks/Notebooks.zip
 
 Have questions about development? Please visit our [Wiki](https://github.com/sqlcollaborative/dbachecks/wiki). **Anyone developing this module** should visit that Wiki page (after fully reading this readme) for a brief overview.
 
@@ -58,11 +58,11 @@ Have questions about development? Please visit our [Wiki](https://github.com/sql
     </tr>
     <tr>
       <td><a href-"https://sqlcollaborative.visualstudio.com/dbachecks/_build/index?context=mine&path=%5C&definitionId=2&_a=completed"><img align="left" src="https://sqlcollaborative.visualstudio.com/_apis/public/build/definitions/a0deae7b-ae38-4ecc-a836-5f79cc561140/2/badge"></a></td>
-      <td>Master Branch Build - Module version update and Code Signing <a href="https://sqlcollaborative.visualstudio.com/dbachecks/_build/index?context=mine&path=%5C&definitionId=2&_a=completed" target="_blank">Click Here</a></td>
+      <td>Main Branch Build - Module version update and Code Signing <a href="https://sqlcollaborative.visualstudio.com/dbachecks/_build/index?context=mine&path=%5C&definitionId=2&_a=completed" target="_blank">Click Here</a></td>
     </tr>
         <tr>
       <td><a href = "https://sqlcollaborative.visualstudio.com/dbachecks/_releases2?definitionId=3&view=mine&_a=releases"><img align="left" src="https://sqlcollaborative.vsrm.visualstudio.com/_apis/public/Release/badge/a0deae7b-ae38-4ecc-a836-5f79cc561140/2/2"></a></td>
-          <td>Master Branch Release - Release to PowerShell Gallery <a href="https://sqlcollaborative.visualstudio.com/dbachecks/_releases2?definitionId=3&view=mine&_a=releases" target="_blank">Click Here</a></td>
+          <td>Main Branch Release - Release to PowerShell Gallery <a href="https://sqlcollaborative.visualstudio.com/dbachecks/_releases2?definitionId=3&view=mine&_a=releases" target="_blank">Click Here</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Fixed branch rename left over docs and links to edit

# A New PR

THANK YOU - We love to get PR's and really appreciate your time and help to improve this module

## Accepting a PR

Before we accept the PR - please confirm that you have run the tests locally to avoid our automated build and release process failing. You can see how to do that in our wiki

https://github.com/sqlcollaborative/dbachecks/wiki 

## Please confirm you have 0 failing Pester Tests

[?] There are 0 failing Pester tests

I updated the docs, so no clue

## Changes this PR brings

* Corrected the outdated "Master Branch" terminology to "Main Branch" in the documentation links.
* Corrected it in the readthedocs config so the `edit` buttons there point to the correct branch

## Potential additional changes not added

Wasn't sure if this would break anything in the build projects

* GitVersion.yml refers to master
* tests/Project.Tests.ps1